### PR TITLE
TRG-634: Relax the Ruby version identifier such that it simply needs to be any 2.7.x release.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby File.read('.ruby-version').strip
+ruby '~> 2.7.0'
 
 gem 'activesupport'
 gem 'chronic'


### PR DESCRIPTION
This seems to resolve an issue whereby, SAM CLI fails to build the Lambda assembly, if the Ruby version in its Docker container doesn't exactly match the Ruby version specified in the Gemfile.